### PR TITLE
Migrate transformer scripts

### DIFF
--- a/fantasy_etl/transformers/core.py
+++ b/fantasy_etl/transformers/core.py
@@ -4,7 +4,7 @@
 """
 
 from typing import Optional, Dict, List
-from datetime import date
+from datetime import date, datetime, timedelta
 
 
 class CoreTransformers:
@@ -20,10 +20,26 @@ class CoreTransformers:
         
         迁移自: archive/yahoo_api_data.py transform_position_string() 第1533行
         """
-        # TODO: 迁移实现
-        # 处理多种位置数据格式
-        # 统一返回位置字符串格式
-        pass
+        if not position_data:
+            return None
+            
+        # 如果是字符串，直接返回
+        if isinstance(position_data, str):
+            return position_data
+            
+        # 如果是字典，查找position键
+        if isinstance(position_data, dict):
+            return position_data.get('position')
+            
+        # 如果是列表，尝试获取第一个元素
+        if isinstance(position_data, list) and len(position_data) > 0:
+            first_item = position_data[0]
+            if isinstance(first_item, str):
+                return first_item
+            elif isinstance(first_item, dict):
+                return first_item.get('position')
+                
+        return None
     
     # ============================================================================
     # 游戏和联盟数据转换
@@ -33,25 +49,89 @@ class CoreTransformers:
         """
         从游戏数据中提取游戏键
         
-        迁移自: archive/yahoo_api_data.py _extract_game_keys() 第175行
+        迁移自: archive/yahoo_api_data.py _extract_game_keys() 第181行
         """
-        # TODO: 迁移实现
-        # 只提取type='full'的完整游戏
-        # 过滤掉测试或不完整的游戏类型
-        # 返回有效的game_key列表
-        pass
+        game_keys = []
+        
+        try:
+            fantasy_content = games_data["fantasy_content"]
+            user_data = fantasy_content["users"]["0"]["user"]
+            games_container = user_data[1]["games"]
+            games_count = int(games_container.get("count", 0))
+            
+            for i in range(games_count):
+                str_index = str(i)
+                if str_index not in games_container:
+                    continue
+                    
+                game_container = games_container[str_index]
+                game_data = game_container["game"]
+                
+                if isinstance(game_data, list) and len(game_data) > 0:
+                    game_info = game_data[0]
+                    game_key = game_info.get("game_key")
+                    game_type = game_info.get("type")
+                    
+                    # 只包含type='full'的游戏
+                    if game_key and game_type == "full":
+                        game_keys.append(game_key)
+                
+        except Exception as e:
+            print(f"提取游戏键时出错: {e}")
+        
+        return game_keys
         
     def transform_leagues_from_data(self, data: Dict, game_key: str) -> List[Dict]:
         """
         从API返回数据中提取联盟信息
         
-        迁移自: archive/yahoo_api_data.py _extract_leagues_from_data() 第206行
+        迁移自: archive/yahoo_api_data.py _extract_leagues_from_data() 第212行
         """
-        # TODO: 迁移实现  
-        # 解析复杂的嵌套API响应结构
-        # 提取每个联盟的详细配置信息
-        # 添加game_key关联信息
-        pass
+        leagues = []
+        
+        try:
+            fantasy_content = data["fantasy_content"]
+            user_data = fantasy_content["users"]["0"]["user"]
+            games_data = user_data[1]["games"]
+            
+            # 找到对应的游戏
+            games_count = int(games_data.get("count", 0))
+            target_game = None
+            
+            for i in range(games_count):
+                str_index = str(i)
+                if str_index in games_data:
+                    game_container = games_data[str_index]
+                    if "game" in game_container:
+                        game_data = game_container["game"]
+                        if isinstance(game_data, list) and len(game_data) > 1:
+                            game_info = game_data[0]
+                            if game_info.get("game_key") == game_key:
+                                target_game = game_data[1]
+                                break
+            
+            if not target_game or "leagues" not in target_game:
+                return leagues
+            
+            leagues_container = target_game["leagues"]
+            leagues_count = int(leagues_container.get("count", 0))
+            
+            for i in range(leagues_count):
+                str_index = str(i)
+                if str_index in leagues_container:
+                    league_container = leagues_container[str_index]
+                    if "league" in league_container:
+                        league_data = league_container["league"]
+                        if isinstance(league_data, list) and len(league_data) > 0:
+                            league_info = league_data[0]
+                            # 添加game_key到联盟信息中
+                            league_info["game_key"] = game_key
+                            leagues.append(league_info)
+                            
+        except Exception as e:
+            print(f"提取联盟信息时出错: {e}")
+        
+        return leagues
     
     # ============================================================================
     # 交易数据转换
@@ -61,26 +141,109 @@ class CoreTransformers:
         """
         从API返回数据中提取交易信息
         
-        迁移自: archive/yahoo_api_data.py _extract_transactions_from_data() 第917行
+        迁移自: archive/yahoo_api_data.py _extract_transactions_from_data() 第936行
         """
-        # TODO: 迁移实现
-        # 解析交易API的复杂响应结构  
-        # 提取每个交易的详细信息
-        # 合并交易相关的所有数据字段
-        pass
+        transactions = []
+        
+        try:
+            fantasy_content = transactions_data["fantasy_content"]
+            league_data = fantasy_content["league"]
+            
+            # 找到transactions容器
+            transactions_container = None
+            if isinstance(league_data, list):
+                for item in league_data:
+                    if isinstance(item, dict) and "transactions" in item:
+                        transactions_container = item["transactions"]
+                        break
+            
+            if not transactions_container:
+                return transactions
+            
+            transactions_count = int(transactions_container.get("count", 0))
+            
+            for i in range(transactions_count):
+                str_index = str(i)
+                if str_index not in transactions_container:
+                    continue
+                
+                transaction_container = transactions_container[str_index]
+                if "transaction" not in transaction_container:
+                    continue
+                
+                transaction_info = transaction_container["transaction"]
+                
+                # 处理不同格式的transaction数据
+                if isinstance(transaction_info, list):
+                    # 合并列表中的所有字典
+                    merged_transaction = {}
+                    for item in transaction_info:
+                        if isinstance(item, dict):
+                            merged_transaction.update(item)
+                    if merged_transaction:
+                        transactions.append(merged_transaction)
+                elif isinstance(transaction_info, dict):
+                    transactions.append(transaction_info)
+        
+        except Exception as e:
+            print(f"提取交易信息时出错: {e}")
+        
+        return transactions
     
     # ============================================================================
     # 日期和时间处理
     # ============================================================================
     
-    def calculate_date_range(self, mode: str, days_back: int = None, target_date: str = None) -> tuple:
+    def calculate_date_range(self, mode: str, season_info: Dict, days_back: int = None, 
+                           target_date: str = None) -> Optional[tuple]:
         """
         计算日期范围
         
         迁移自: archive/yahoo_api_data.py calculate_date_range() 第1257行
         """
-        # TODO: 迁移实现
-        # 支持3种模式：指定日期/天数回溯/完整赛季
-        # 自动限制在赛季有效范围内  
-        # 返回计算好的开始和结束日期
-        pass
+        if not season_info:
+            print("❌ 无法获取赛季信息")
+            return None
+        
+        if mode == "specific":
+            # 指定日期模式
+            if not target_date:
+                print("❌ 指定日期模式需要提供target_date")
+                return None
+            try:
+                target = datetime.strptime(target_date, '%Y-%m-%d').date()
+                # 检查日期是否在赛季范围内
+                if target < season_info["start_date"] or target > season_info["end_date"]:
+                    print(f"⚠️ 指定日期 {target_date} 不在赛季范围内 ({season_info['start_date']} 到 {season_info['end_date']})")
+                return (target, target)
+            except ValueError:
+                print(f"❌ 日期格式错误: {target_date}")
+                return None
+        
+        elif mode == "days_back":
+            # 天数回溯模式
+            if days_back is None:
+                print("❌ 天数回溯模式需要提供days_back")
+                return None
+            
+            # 从最新日期向前回溯
+            end_date = season_info["latest_date"]
+            start_date = end_date - timedelta(days=days_back)
+            
+            # 确保不超出赛季范围
+            start_date = max(start_date, season_info["start_date"])
+            
+            print(f"📅 天数回溯模式: 从 {start_date} 到 {end_date} (回溯{days_back}天，赛季状态: {season_info['season_status']})")
+            return (start_date, end_date)
+        
+        elif mode == "full_season":
+            # 完整赛季模式
+            start_date = season_info["start_date"]
+            end_date = season_info["end_date"]
+            
+            print(f"📅 完整赛季模式: 从 {start_date} 到 {end_date}")
+            return (start_date, end_date)
+        
+        else:
+            print(f"❌ 不支持的模式: {mode}")
+            return None

--- a/fantasy_etl/transformers/player.py
+++ b/fantasy_etl/transformers/player.py
@@ -4,6 +4,7 @@ Player数据转换器
 """
 
 from typing import Dict, List
+from datetime import datetime
 
 
 class PlayerTransformers:
@@ -13,22 +14,105 @@ class PlayerTransformers:
         """
         从联盟球员数据中提取球员信息
         
-        迁移自: archive/yahoo_api_data.py _extract_player_info_from_league_data() 第779行
+        迁移自: archive/yahoo_api_data.py _extract_player_info_from_league_data() 第798行
         """
-        # TODO: 迁移实现
-        # 解析复杂的球员API响应结构
-        # 提取球员基本信息和属性  
-        # 规范化球员数据格式
-        pass
+        players = []
         
-    def transform_player_info(self, player_info: Dict) -> Dict:
+        try:
+            fantasy_content = players_data["fantasy_content"]
+            league_data = fantasy_content["league"]
+            
+            # 找到players容器
+            players_container = None
+            if isinstance(league_data, list):
+                for item in league_data:
+                    if isinstance(item, dict) and "players" in item:
+                        players_container = item["players"]
+                        break
+            
+            if not players_container:
+                return players
+            
+            players_count = int(players_container.get("count", 0))
+            
+            for i in range(players_count):
+                str_index = str(i)
+                if str_index not in players_container:
+                    continue
+                
+                player_container = players_container[str_index]
+                if "player" not in player_container:
+                    continue
+                
+                player_info_list = player_container["player"]
+                if not isinstance(player_info_list, list) or len(player_info_list) == 0:
+                    continue
+                
+                # 合并player信息
+                player_info = {}
+                for item in player_info_list:
+                    if isinstance(item, dict):
+                        player_info.update(item)
+                
+                if player_info:
+                    players.append(player_info)
+                    
+        except Exception as e:
+            print(f"提取球员信息时出错: {e}")
+        
+        return players
+        
+    def transform_player_info(self, player_info: Dict, league_key: str, season: str) -> Dict:
         """
         标准化球员信息
         
         迁移自: archive/yahoo_api_data.py _normalize_player_info() 第832行
         """
-        # TODO: 迁移实现  
-        # 处理姓名、团队、头像信息
-        # 统一字段命名和数据格式
-        # 添加时间戳和赛季信息
-        pass
+        normalized = {}
+        
+        # 基本信息
+        normalized['player_key'] = player_info.get('player_key')
+        normalized['player_id'] = player_info.get('player_id')
+        normalized['editorial_player_key'] = player_info.get('editorial_player_key')
+        normalized['editorial_team_key'] = player_info.get('editorial_team_key')
+        normalized['editorial_team_full_name'] = player_info.get('editorial_team_full_name')
+        normalized['editorial_team_abbr'] = player_info.get('editorial_team_abbr')
+        
+        # 姓名处理
+        name_info = player_info.get('name', {})
+        if isinstance(name_info, dict):
+            normalized['first_name'] = name_info.get('first', '')
+            normalized['last_name'] = name_info.get('last', '')
+            normalized['full_name'] = name_info.get('full', '')
+        else:
+            # 如果name不是字典，尝试从其他字段获取
+            normalized['first_name'] = player_info.get('first_name', '')
+            normalized['last_name'] = player_info.get('last_name', '')
+            normalized['full_name'] = player_info.get('full_name', '')
+        
+        # 其他信息
+        normalized['uniform_number'] = player_info.get('uniform_number')
+        normalized['display_position'] = player_info.get('display_position')
+        normalized['position_type'] = player_info.get('position_type')
+        
+        # 头像信息
+        headshot_info = player_info.get('headshot', {})
+        if isinstance(headshot_info, dict):
+            normalized['headshot_url'] = headshot_info.get('url')
+        else:
+            normalized['headshot_url'] = player_info.get('image_url')
+        
+        # 状态信息
+        normalized['is_undroppable'] = player_info.get('is_undroppable', 0)
+        normalized['has_player_notes'] = player_info.get('has_player_notes', 0)
+        normalized['has_recent_player_notes'] = player_info.get('has_recent_player_notes', 0)
+        
+        # 添加联盟和赛季信息
+        normalized['league_key'] = league_key
+        normalized['season'] = season
+        
+        # 添加时间戳
+        normalized['created_at'] = datetime.now()
+        normalized['updated_at'] = datetime.now()
+        
+        return normalized

--- a/fantasy_etl/transformers/roster.py
+++ b/fantasy_etl/transformers/roster.py
@@ -4,16 +4,21 @@ Roster数据转换器
 """
 
 from typing import Optional, List, Dict
+from .core import CoreTransformers
 
 
 class RosterTransformers:
     """Roster数据转换器"""
     
+    def __init__(self):
+        """初始化转换器"""
+        self.core_transformer = CoreTransformers()
+    
     def transform_roster_data(self, roster_data: Dict, team_key: str) -> Optional[List[Dict]]:
         """
         从原始roster数据转换为标准化格式 (纯转换，不写入数据库)
         
-        迁移自: archive/yahoo_api_data.py transform_roster_data() 第519行
+        迁移自: archive/yahoo_api_data.py transform_roster_data() 第518行
         
         Args:
             roster_data: 原始Yahoo API roster响应数据
@@ -22,14 +27,126 @@ class RosterTransformers:
         Returns:
             转换后的roster数据列表，或None如果转换失败
         """
-        # TODO: 迁移完整实现 (第519-609行)
-        # 主要逻辑：
-        # 1. 解析fantasy_content.team结构
-        # 2. 提取roster信息和球员列表
-        # 3. 处理每个球员的基本信息和位置数据
-        # 4. 创建标准化的roster_entry记录
-        # 5. 处理keeper信息（如果存在）
-        # 6. 返回完整的roster_list
+        if not roster_data:
+            return None
         
-        # 依赖: self.transform_position_string() - 需要从core导入
-        pass
+        try:
+            # 解析roster数据
+            fantasy_content = roster_data.get("fantasy_content", {})
+            team_data = fantasy_content.get("team", [])
+            
+            # 查找roster信息
+            roster_info = None
+            for item in team_data:
+                if isinstance(item, dict) and "roster" in item:
+                    roster_info = item["roster"]
+                    break
+            
+            if not roster_info:
+                return None
+            
+            # 提取coverage信息（日期）
+            coverage_type = roster_info.get("coverage_type", "")
+            coverage_value = roster_info.get("coverage_value", "")
+            
+            # 提取球员列表
+            players_container = roster_info.get("0", {}).get("players", {})
+            players_count = int(players_container.get("count", 0))
+            
+            roster_list = []
+            
+            for i in range(players_count):
+                str_index = str(i)
+                if str_index not in players_container:
+                    continue
+                
+                player_container = players_container[str_index]
+                player_data = player_container.get("player", [])
+                
+                # 合并球员信息
+                player_info = {}
+                selected_position_info = {}
+                
+                for item in player_data:
+                    if isinstance(item, dict):
+                        # 检查是否是selected_position信息
+                        if "selected_position" in item:
+                            selected_position_info = item["selected_position"][0] if isinstance(item["selected_position"], list) else item["selected_position"]
+                        else:
+                            player_info.update(item)
+                
+                if not player_info:
+                    continue
+                
+                # 提取基本信息
+                player_key = player_info.get("player_key")
+                player_id = player_info.get("player_id")
+                
+                # 提取姓名
+                name_info = player_info.get("name", {})
+                if isinstance(name_info, dict):
+                    full_name = name_info.get("full", "")
+                else:
+                    full_name = player_info.get("full_name", "")
+                
+                # 提取位置信息
+                eligible_positions = player_info.get("eligible_positions", [])
+                if isinstance(eligible_positions, list):
+                    position_list = eligible_positions
+                else:
+                    # 尝试从其他格式提取位置
+                    position_list = []
+                    if isinstance(eligible_positions, dict) and "position" in eligible_positions:
+                        positions = eligible_positions["position"]
+                        if isinstance(positions, list):
+                            position_list = positions
+                        elif isinstance(positions, str):
+                            position_list = [positions]
+                
+                # 提取选定位置
+                selected_position = selected_position_info.get("position", "")
+                if not selected_position and position_list:
+                    selected_position = self.core_transformer.transform_position_string(position_list[0])
+                
+                # 提取其他信息
+                is_flex = selected_position_info.get("is_flex", 0)
+                has_recent_player_notes = player_info.get("has_recent_player_notes", 0)
+                status = player_info.get("status", "")
+                status_full = player_info.get("status_full", "")
+                
+                # 构建roster entry
+                roster_entry = {
+                    "team_key": team_key,
+                    "player_key": player_key,
+                    "player_id": player_id,
+                    "full_name": full_name,
+                    "selected_position": selected_position,
+                    "eligible_positions": position_list,
+                    "is_flex": is_flex,
+                    "has_recent_player_notes": has_recent_player_notes,
+                    "status": status,
+                    "status_full": status_full,
+                    "coverage_type": coverage_type,
+                    "coverage_value": coverage_value
+                }
+                
+                # 检查是否是keeper
+                is_keeper = player_info.get("is_keeper")
+                if is_keeper:
+                    roster_entry["is_keeper"] = 1
+                    roster_entry["keeper_cost"] = player_info.get("keeper_cost")
+                else:
+                    roster_entry["is_keeper"] = 0
+                    roster_entry["keeper_cost"] = None
+                
+                # 添加是否可编辑标志
+                is_editable = player_info.get("is_editable", 1)
+                roster_entry["is_editable"] = is_editable
+                
+                roster_list.append(roster_entry)
+            
+            return roster_list
+            
+        except Exception as e:
+            print(f"转换roster数据时出错: {e}")
+            return None

--- a/fantasy_etl/transformers/stats.py
+++ b/fantasy_etl/transformers/stats.py
@@ -3,7 +3,7 @@
 处理各种统计数据的转换逻辑
 """
 
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 from datetime import date
 
 
@@ -18,134 +18,607 @@ class StatsTransformers:
         """
         从matchup数据中提取核心统计项
         
-        迁移自: archive/database_writer.py transform_core_team_weekly_stats() 第778行
+        迁移自: archive/database_writer.py transform_core_team_weekly_stats() 第777行
         """
-        # TODO: 迁移实现
-        # 简化的统计提取方法
-        # 主要处理获胜类别数量
-        # 用于对战结果分析
-        pass
+        return {
+            'categories_won': categories_won,
+            'is_winner': 1 if win else 0 if win is not None else None
+        }
         
     def transform_team_season_stats(self, stats_data: Dict) -> Dict:
         """
         从团队赛季统计数据中提取完整统计项
         
-        迁移自: archive/database_writer.py transform_team_season_stats() 第1894行
+        迁移自: archive/database_writer.py transform_team_season_stats() 第1893行
         """
-        # TODO: 迁移实现
-        # 从team_standings提取排名和战绩信息
-        # 处理outcome_totals中的胜负记录
-        # 提取分区战绩和总积分信息
-        # 安全的数据提取和类型转换
-        pass
+        season_stats = {}
+        
+        try:
+            # 提取排名和战绩信息
+            team_standings = stats_data.get('team_standings', {})
+            season_stats['rank'] = self._safe_int(team_standings.get('rank'))
+            season_stats['playoff_seed'] = team_standings.get('playoff_seed')
+            
+            # 提取胜负记录
+            outcome_totals = team_standings.get('outcome_totals', {})
+            season_stats['wins'] = self._safe_int(outcome_totals.get('wins'))
+            season_stats['losses'] = self._safe_int(outcome_totals.get('losses'))
+            season_stats['ties'] = self._safe_int(outcome_totals.get('ties'))
+            season_stats['percentage'] = self._safe_float(outcome_totals.get('percentage'))
+            
+            # 提取分区战绩
+            divisional_outcome_totals = team_standings.get('divisional_outcome_totals', {})
+            season_stats['divisional_wins'] = self._safe_int(divisional_outcome_totals.get('wins'))
+            season_stats['divisional_losses'] = self._safe_int(divisional_outcome_totals.get('losses'))
+            season_stats['divisional_ties'] = self._safe_int(divisional_outcome_totals.get('ties'))
+            
+            # 提取积分信息
+            points_for = team_standings.get('points_for')
+            if points_for:
+                season_stats['points_for'] = self._safe_float(points_for)
+            else:
+                season_stats['points_for'] = None
+            
+            points_against = team_standings.get('points_against')
+            if points_against:
+                season_stats['points_against'] = self._safe_float(points_against)
+            else:
+                season_stats['points_against'] = None
+                
+        except Exception as e:
+            print(f"提取团队赛季统计失败: {e}")
+        
+        return season_stats
         
     def transform_team_weekly_stats_from_stats_data(self, stats_data: Dict) -> Dict:
         """
         从团队周统计数据中提取完整的11个统计项
         
-        迁移自: archive/database_writer.py transform_team_weekly_stats_from_stats_data() 第1931行
+        迁移自: archive/database_writer.py transform_team_weekly_stats_from_stats_data() 第1930行
         """
-        # TODO: 迁移实现
-        # 解析stats数组构建stat_id映射
-        # 提取完整的11个核心篮球统计项
-        # 处理FGM/A、FTM/A等复合统计格式
-        # 统一的百分比和数值处理
-        pass
+        weekly_stats = {}
+        
+        try:
+            # 首先构建stat_id到值的映射
+            stat_map = {}
+            stats_list = stats_data.get('stats', [])
+            if isinstance(stats_list, list):
+                for stat in stats_list:
+                    if isinstance(stat, dict) and 'stat' in stat:
+                        stat_info = stat['stat']
+                        stat_id = stat_info.get('stat_id')
+                        value = stat_info.get('value')
+                        if stat_id and value is not None:
+                            stat_map[str(stat_id)] = value
+            
+            # 提取11个核心统计项
+            
+            # 1. Field Goals Made / Attempted (FGM/A)
+            field_goals_data = stat_map.get('9004003', '')
+            if isinstance(field_goals_data, str) and '/' in field_goals_data:
+                try:
+                    made, attempted = field_goals_data.split('/')
+                    weekly_stats['field_goals_made'] = self._safe_int(made.strip())
+                    weekly_stats['field_goals_attempted'] = self._safe_int(attempted.strip())
+                except:
+                    weekly_stats['field_goals_made'] = None
+                    weekly_stats['field_goals_attempted'] = None
+            else:
+                weekly_stats['field_goals_made'] = None
+                weekly_stats['field_goals_attempted'] = None
+            
+            # 2. Field Goal Percentage (FG%)
+            fg_pct_str = stat_map.get('5', '')
+            if fg_pct_str and fg_pct_str != '-':
+                weekly_stats['field_goal_percentage'] = self._parse_percentage(fg_pct_str)
+            else:
+                weekly_stats['field_goal_percentage'] = None
+            
+            # 3. Free Throws Made / Attempted (FTM/A)
+            free_throws_data = stat_map.get('9007006', '')
+            if isinstance(free_throws_data, str) and '/' in free_throws_data:
+                try:
+                    made, attempted = free_throws_data.split('/')
+                    weekly_stats['free_throws_made'] = self._safe_int(made.strip())
+                    weekly_stats['free_throws_attempted'] = self._safe_int(attempted.strip())
+                except:
+                    weekly_stats['free_throws_made'] = None
+                    weekly_stats['free_throws_attempted'] = None
+            else:
+                weekly_stats['free_throws_made'] = None
+                weekly_stats['free_throws_attempted'] = None
+            
+            # 4. Free Throw Percentage (FT%)
+            ft_pct_str = stat_map.get('8', '')
+            if ft_pct_str and ft_pct_str != '-':
+                weekly_stats['free_throw_percentage'] = self._parse_percentage(ft_pct_str)
+            else:
+                weekly_stats['free_throw_percentage'] = None
+            
+            # 5. 3-point Shots Made (3PTM)
+            weekly_stats['three_pointers_made'] = self._safe_int(stat_map.get('10'))
+            
+            # 6. Points Scored (PTS)
+            weekly_stats['total_points'] = self._safe_int(stat_map.get('12'))
+            
+            # 7. Total Rebounds (REB)
+            weekly_stats['total_rebounds'] = self._safe_int(stat_map.get('15'))
+            
+            # 8. Assists (AST)
+            weekly_stats['total_assists'] = self._safe_int(stat_map.get('16'))
+            
+            # 9. Steals (ST)
+            weekly_stats['total_steals'] = self._safe_int(stat_map.get('17'))
+            
+            # 10. Blocked Shots (BLK)
+            weekly_stats['total_blocks'] = self._safe_int(stat_map.get('18'))
+            
+            # 11. Turnovers (TO)
+            weekly_stats['total_turnovers'] = self._safe_int(stat_map.get('19'))
+            
+        except Exception as e:
+            print(f"提取团队周统计失败: {e}")
+        
+        return weekly_stats
         
     def transform_core_player_season_stats(self, stats_data: Dict) -> Dict:
         """
         从球员赛季统计数据中提取完整的11个统计项
         
         迁移自: archive/database_writer.py transform_player_season_stats() 第487行
-        注意：原函数名为 _extract_core_player_season_stats
         """
-        # TODO: 迁移实现
-        # 基于Yahoo stat_categories的标准映射
-        # 处理百分比格式转换
-        # 安全解析复合统计项（FGM/A格式）
-        # 返回标准化的统计字典
-        pass
+        core_stats = {}
+        
+        try:
+            # 完整的11个统计项（基于Yahoo stat_categories）
+            
+            # 1. stat_id: 9004003 - Field Goals Made / Attempted (FGM/A)
+            field_goals_data = stats_data.get('9004003', '')
+            if isinstance(field_goals_data, str) and '/' in field_goals_data:
+                try:
+                    made, attempted = field_goals_data.split('/')
+                    core_stats['field_goals_made'] = self._safe_int(made.strip())
+                    core_stats['field_goals_attempted'] = self._safe_int(attempted.strip())
+                except:
+                    core_stats['field_goals_made'] = None
+                    core_stats['field_goals_attempted'] = None
+            else:
+                core_stats['field_goals_made'] = None
+                core_stats['field_goals_attempted'] = None
+            
+            # 2. stat_id: 5 - Field Goal Percentage (FG%)
+            fg_pct_str = stats_data.get('5', '')
+            if fg_pct_str and fg_pct_str != '-':
+                core_stats['field_goal_percentage'] = self._parse_percentage(fg_pct_str)
+            else:
+                core_stats['field_goal_percentage'] = None
+            
+            # 3. stat_id: 9007006 - Free Throws Made / Attempted (FTM/A)
+            free_throws_data = stats_data.get('9007006', '')
+            if isinstance(free_throws_data, str) and '/' in free_throws_data:
+                try:
+                    made, attempted = free_throws_data.split('/')
+                    core_stats['free_throws_made'] = self._safe_int(made.strip())
+                    core_stats['free_throws_attempted'] = self._safe_int(attempted.strip())
+                except:
+                    core_stats['free_throws_made'] = None
+                    core_stats['free_throws_attempted'] = None
+            else:
+                core_stats['free_throws_made'] = None
+                core_stats['free_throws_attempted'] = None
+            
+            # 4. stat_id: 8 - Free Throw Percentage (FT%)
+            ft_pct_str = stats_data.get('8', '')
+            if ft_pct_str and ft_pct_str != '-':
+                core_stats['free_throw_percentage'] = self._parse_percentage(ft_pct_str)
+            else:
+                core_stats['free_throw_percentage'] = None
+            
+            # 5. stat_id: 10 - 3-point Shots Made (3PTM)
+            core_stats['three_pointers_made'] = self._safe_int(stats_data.get('10'))
+            
+            # 6. stat_id: 12 - Points Scored (PTS)
+            core_stats['total_points'] = self._safe_int(stats_data.get('12'))
+            
+            # 7. stat_id: 15 - Total Rebounds (REB)
+            core_stats['total_rebounds'] = self._safe_int(stats_data.get('15'))
+            
+            # 8. stat_id: 16 - Assists (AST)
+            core_stats['total_assists'] = self._safe_int(stats_data.get('16'))
+            
+            # 9. stat_id: 17 - Steals (ST)
+            core_stats['total_steals'] = self._safe_int(stats_data.get('17'))
+            
+            # 10. stat_id: 18 - Blocked Shots (BLK)
+            core_stats['total_blocks'] = self._safe_int(stats_data.get('18'))
+            
+            # 11. stat_id: 19 - Turnovers (TO)
+            core_stats['total_turnovers'] = self._safe_int(stats_data.get('19'))
+            
+        except Exception as e:
+            print(f"提取核心赛季统计失败: {e}")
+        
+        return core_stats
         
     def transform_core_daily_stats(self, stats_data: Dict) -> Dict:
         """
         从统计数据中提取完整的11个日期统计项
         
-        迁移自: archive/database_writer.py transform_player_daily_stats() 第630行
-        注意：原函数名为 _extract_core_daily_stats
+        迁移自: archive/database_writer.py transform_player_daily_stats() 第629行
         """
-        # TODO: 迁移实现
-        # 与赛季统计提取逻辑类似
-        # 处理日统计的特殊格式
-        # 统一的百分比和数值转换
-        pass
+        core_stats = {}
+        
+        try:
+            # 完整的11个统计项（基于Yahoo stat_categories）
+            
+            # 1. stat_id: 9004003 - Field Goals Made / Attempted (FGM/A)
+            field_goals_data = stats_data.get('9004003', '')
+            if isinstance(field_goals_data, str) and '/' in field_goals_data:
+                try:
+                    made, attempted = field_goals_data.split('/')
+                    core_stats['field_goals_made'] = self._safe_int(made.strip())
+                    core_stats['field_goals_attempted'] = self._safe_int(attempted.strip())
+                except:
+                    core_stats['field_goals_made'] = None
+                    core_stats['field_goals_attempted'] = None
+            else:
+                core_stats['field_goals_made'] = None
+                core_stats['field_goals_attempted'] = None
+            
+            # 2. stat_id: 5 - Field Goal Percentage (FG%)
+            fg_pct_str = stats_data.get('5', '')
+            if fg_pct_str and fg_pct_str != '-':
+                core_stats['field_goal_percentage'] = self._parse_percentage(fg_pct_str)
+            else:
+                core_stats['field_goal_percentage'] = None
+            
+            # 3. stat_id: 9007006 - Free Throws Made / Attempted (FTM/A)
+            free_throws_data = stats_data.get('9007006', '')
+            if isinstance(free_throws_data, str) and '/' in free_throws_data:
+                try:
+                    made, attempted = free_throws_data.split('/')
+                    core_stats['free_throws_made'] = self._safe_int(made.strip())
+                    core_stats['free_throws_attempted'] = self._safe_int(attempted.strip())
+                except:
+                    core_stats['free_throws_made'] = None
+                    core_stats['free_throws_attempted'] = None
+            else:
+                core_stats['free_throws_made'] = None
+                core_stats['free_throws_attempted'] = None
+            
+            # 4. stat_id: 8 - Free Throw Percentage (FT%)
+            ft_pct_str = stats_data.get('8', '')
+            if ft_pct_str and ft_pct_str != '-':
+                core_stats['free_throw_percentage'] = self._parse_percentage(ft_pct_str)
+            else:
+                core_stats['free_throw_percentage'] = None
+            
+            # 5. stat_id: 10 - 3-point Shots Made (3PTM)
+            core_stats['three_pointers_made'] = self._safe_int(stats_data.get('10'))
+            
+            # 6. stat_id: 12 - Points Scored (PTS)
+            core_stats['total_points'] = self._safe_int(stats_data.get('12'))
+            
+            # 7. stat_id: 15 - Total Rebounds (REB)
+            core_stats['total_rebounds'] = self._safe_int(stats_data.get('15'))
+            
+            # 8. stat_id: 16 - Assists (AST)
+            core_stats['total_assists'] = self._safe_int(stats_data.get('16'))
+            
+            # 9. stat_id: 17 - Steals (ST)
+            core_stats['total_steals'] = self._safe_int(stats_data.get('17'))
+            
+            # 10. stat_id: 18 - Blocked Shots (BLK)
+            core_stats['total_blocks'] = self._safe_int(stats_data.get('18'))
+            
+            # 11. stat_id: 19 - Turnovers (TO)
+            core_stats['total_turnovers'] = self._safe_int(stats_data.get('19'))
+            
+        except Exception as e:
+            print(f"提取核心日统计失败: {e}")
+        
+        return core_stats
     
     # ============================================================================
     # 从 archive/yahoo_api_data.py 迁移的统计处理函数
     # ============================================================================
     
-    def process_player_season_stats_data(self, stats_data: Dict, league_key: str, season: str) -> int:
+    def transform_player_season_stats_batch(self, stats_data: Dict) -> List[Dict]:
         """
-        处理球员赛季统计数据
+        处理球员赛季统计数据批次
         
-        迁移自: archive/yahoo_api_data.py _process_player_season_stats_data() 第1911行
-        注意：这个函数可能包含数据库写入逻辑，需要拆分为transform和load
+        迁移自: archive/yahoo_api_data.py _process_player_season_stats_data() 第1975行
+        返回转换后的统计数据列表
         """
-        # TODO: 迁移并拆分实现
-        # 解析批量统计API响应
-        # 提取每个球员的11项核心统计
-        # 分离转换逻辑和写入逻辑
-        pass
+        transformed_stats = []
         
-    def process_player_daily_stats_data(self, stats_data: Dict, league_key: str, 
-                                      season: str, date_obj: date) -> int:
-        """
-        处理球员日统计数据
+        try:
+            fantasy_content = stats_data.get("fantasy_content", {})
+            league_data = fantasy_content.get("league", [])
+            
+            # 找到players容器
+            players_container = None
+            if isinstance(league_data, list):
+                for item in league_data:
+                    if isinstance(item, dict) and "players" in item:
+                        players_container = item["players"]
+                        break
+            
+            if not players_container:
+                return transformed_stats
+            
+            players_count = int(players_container.get("count", 0))
+            
+            for i in range(players_count):
+                str_index = str(i)
+                if str_index not in players_container:
+                    continue
+                
+                player_container = players_container[str_index]
+                player_data = player_container.get("player", [])
+                
+                # 合并球员信息和统计数据
+                player_info = {}
+                player_stats_raw = {}
+                
+                for item in player_data:
+                    if isinstance(item, dict):
+                        if "player_stats" in item:
+                            stats_info = item["player_stats"]
+                            if isinstance(stats_info, dict) and "stats" in stats_info:
+                                stats_list = stats_info["stats"]
+                                if isinstance(stats_list, list):
+                                    for stat in stats_list:
+                                        if isinstance(stat, dict) and "stat" in stat:
+                                            stat_detail = stat["stat"]
+                                            stat_id = stat_detail.get("stat_id")
+                                            value = stat_detail.get("value")
+                                            if stat_id and value is not None:
+                                                player_stats_raw[str(stat_id)] = value
+                        else:
+                            player_info.update(item)
+                
+                if player_info and player_stats_raw:
+                    # 提取核心统计
+                    core_stats = self.transform_core_player_season_stats(player_stats_raw)
+                    
+                    # 组合球员信息和统计
+                    transformed_stat = {
+                        'player_key': player_info.get('player_key'),
+                        'editorial_player_key': player_info.get('editorial_player_key'),
+                        'stats': core_stats
+                    }
+                    transformed_stats.append(transformed_stat)
+                    
+        except Exception as e:
+            print(f"处理球员赛季统计批次失败: {e}")
         
-        迁移自: archive/yahoo_api_data.py _process_player_daily_stats_data() 第2022行
-        注意：这个函数可能包含数据库写入逻辑，需要拆分为transform和load
-        """
-        # TODO: 迁移并拆分实现
-        # 解析日统计API响应
-        # 提取指定日期的球员表现
-        # 分离转换逻辑和写入逻辑
-        pass
+        return transformed_stats
         
-    def process_matchup_to_weekly_stats(self, team_key: str, week: int, opponent_team_key: str, 
-                                      is_playoffs: bool, is_winner: Optional[bool], team_points: int, 
-                                      matchup_data: Dict, league_key: str, season: str) -> bool:
+    def transform_player_daily_stats_batch(self, stats_data: Dict, stats_date: date) -> List[Dict]:
         """
-        将对战记录处理为周统计数据
+        处理球员日统计数据批次
         
-        迁移自: archive/yahoo_api_data.py _process_matchup_to_weekly_stats() 第2574行
-        注意：这个函数可能包含数据库写入逻辑，需要拆分为transform和load
+        迁移自: archive/yahoo_api_data.py _process_player_daily_stats_data() 第2086行
+        返回转换后的统计数据列表
         """
-        # TODO: 迁移并拆分实现
-        # 提取对战中的统计表现
+        transformed_stats = []
+        
+        try:
+            fantasy_content = stats_data.get("fantasy_content", {})
+            league_data = fantasy_content.get("league", [])
+            
+            # 找到players容器
+            players_container = None
+            if isinstance(league_data, list):
+                for item in league_data:
+                    if isinstance(item, dict) and "players" in item:
+                        players_container = item["players"]
+                        break
+            
+            if not players_container:
+                return transformed_stats
+            
+            players_count = int(players_container.get("count", 0))
+            
+            for i in range(players_count):
+                str_index = str(i)
+                if str_index not in players_container:
+                    continue
+                
+                player_container = players_container[str_index]
+                player_data = player_container.get("player", [])
+                
+                # 合并球员信息和统计数据
+                player_info = {}
+                player_stats_raw = {}
+                
+                for item in player_data:
+                    if isinstance(item, dict):
+                        if "player_stats" in item:
+                            stats_info = item["player_stats"]
+                            if isinstance(stats_info, dict) and "stats" in stats_info:
+                                stats_list = stats_info["stats"]
+                                if isinstance(stats_list, list):
+                                    for stat in stats_list:
+                                        if isinstance(stat, dict) and "stat" in stat:
+                                            stat_detail = stat["stat"]
+                                            stat_id = stat_detail.get("stat_id")
+                                            value = stat_detail.get("value")
+                                            if stat_id and value is not None:
+                                                player_stats_raw[str(stat_id)] = value
+                        else:
+                            player_info.update(item)
+                
+                if player_info and player_stats_raw:
+                    # 提取核心统计
+                    core_stats = self.transform_core_daily_stats(player_stats_raw)
+                    
+                    # 组合球员信息和统计
+                    transformed_stat = {
+                        'player_key': player_info.get('player_key'),
+                        'editorial_player_key': player_info.get('editorial_player_key'),
+                        'stats_date': stats_date,
+                        'stats': core_stats
+                    }
+                    transformed_stats.append(transformed_stat)
+                    
+        except Exception as e:
+            print(f"处理球员日统计批次失败: {e}")
+        
+        return transformed_stats
+        
+    def transform_matchup_to_weekly_stats(self, team_key: str, week: int, opponent_team_key: str, 
+                                        is_playoffs: bool, is_winner: Optional[bool], team_points: int, 
+                                        matchup_data: Dict) -> Dict:
+        """
+        将对战记录转换为周统计数据
+        
+        迁移自: archive/yahoo_api_data.py _process_matchup_to_weekly_stats() 第2491行
+        返回转换后的周统计数据
+        """
+        # 从matchup数据中提取团队统计
+        team_stats = self.transform_team_stats_from_matchup(matchup_data, team_key)
+        
+        if not team_stats:
+            return None
+        
         # 计算获胜的统计类别数量
-        # 分离转换逻辑和写入逻辑
-        pass
+        categories_won = self.count_categories_won(matchup_data, team_key)
         
-    def process_standing_to_season_stats(self, standing, league_key: str, season: str) -> bool:
-        """
-        将排名记录处理为赛季统计数据
+        # 构建周统计数据
+        weekly_stats = {
+            'team_key': team_key,
+            'week': week,
+            'opponent_team_key': opponent_team_key,
+            'is_playoffs': is_playoffs,
+            'is_winner': is_winner,
+            'team_points': team_points,
+            'categories_won': categories_won,
+            'stats': team_stats
+        }
         
-        迁移自: archive/yahoo_api_data.py _process_standing_to_season_stats() 第2709行
-        注意：这个函数可能包含数据库写入逻辑，需要拆分为transform和load
+        return weekly_stats
+        
+    def transform_standing_to_season_stats(self, standing: Dict) -> Dict:
         """
-        # TODO: 迁移并拆分实现
-        # 从排名数据提取赛季表现
-        # 计算胜率和排名信息
-        # 分离转换逻辑和写入逻辑
-        pass
+        将排名记录转换为赛季统计数据
+        
+        迁移自: archive/yahoo_api_data.py _process_standing_to_season_stats() 第2626行
+        返回转换后的赛季统计数据
+        """
+        # 提取赛季统计
+        season_stats = self.transform_team_season_stats({'team_standings': standing})
+        
+        # 构建完整的赛季统计记录
+        transformed_stats = {
+            'team_key': standing.get('team_key'),
+            'rank': standing.get('rank'),
+            'playoff_seed': standing.get('playoff_seed'),
+            'wins': standing.get('wins', 0),
+            'losses': standing.get('losses', 0),
+            'ties': standing.get('ties', 0),
+            'win_percentage': standing.get('win_percentage', 0.0),
+            'games_back': standing.get('games_back', '-'),
+            'divisional_wins': standing.get('divisional_wins', 0),
+            'divisional_losses': standing.get('divisional_losses', 0),
+            'divisional_ties': standing.get('divisional_ties', 0),
+            'stats': season_stats
+        }
+        
+        return transformed_stats
         
     def count_categories_won(self, matchup_data: Dict, team_key: str) -> int:
         """
         计算团队在对战中获胜的统计类别数量
         
-        迁移自: archive/yahoo_api_data.py _count_categories_won() 第2646行
+        迁移自: archive/yahoo_api_data.py _count_categories_won() 第2563行
         """
-        # TODO: 迁移实现
-        # 比较两个团队在各统计类别的表现
-        # 统计目标团队获胜的类别数量
-        # 用于计算对战胜负
-        pass
+        categories_won = 0
+        
+        try:
+            # 从matchup数据中提取stat_winners信息
+            stat_winners = matchup_data.get('stat_winners', [])
+            
+            if isinstance(stat_winners, list):
+                for winner in stat_winners:
+                    if isinstance(winner, dict):
+                        stat_winner = winner.get('stat_winner', {})
+                        winner_team_key = stat_winner.get('winner_team_key')
+                        if winner_team_key == team_key:
+                            categories_won += 1
+                            
+        except Exception as e:
+            print(f"计算获胜类别数量失败: {e}")
+        
+        return categories_won
+        
+    def transform_team_stats_from_matchup(self, matchup_data: Dict, target_team_key: str) -> Optional[Dict]:
+        """
+        从对战数据中提取团队统计
+        
+        迁移自: archive/yahoo_api_data.py transform_team_stats_from_matchup() 第2514行
+        """
+        try:
+            # 查找teams数据
+            teams = matchup_data.get('teams', [])
+            
+            for team in teams:
+                if isinstance(team, dict):
+                    team_data = team.get('team', {})
+                    team_key = team_data.get('team_key')
+                    
+                    if team_key == target_team_key:
+                        # 找到目标团队，提取统计数据
+                        team_stats = team_data.get('team_stats', {})
+                        if team_stats:
+                            return self.transform_team_weekly_stats_from_stats_data(team_stats)
+                            
+        except Exception as e:
+            print(f"从对战数据提取团队统计失败: {e}")
+        
+        return None
+    
+    # ============================================================================
+    # 辅助函数
+    # ============================================================================
+    
+    def _safe_int(self, value) -> Optional[int]:
+        """安全转换为整数"""
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return None
+    
+    def _safe_float(self, value) -> Optional[float]:
+        """安全转换为浮点数"""
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return None
+    
+    def _parse_percentage(self, pct_str) -> Optional[float]:
+        """解析百分比字符串，返回百分比值（0-100）"""
+        if not pct_str:
+            return None
+        
+        try:
+            # 移除百分号（如果有）
+            pct_str = str(pct_str).strip().rstrip('%')
+            
+            # 转换为浮点数
+            value = float(pct_str)
+            
+            # 如果值小于1，假设是小数形式（如0.500），转换为百分比
+            if value <= 1.0:
+                value = value * 100
+            
+            # 四舍五入到一位小数
+            return round(value, 1)
+            
+        except (ValueError, TypeError):
+            return None

--- a/fantasy_etl/transformers/team.py
+++ b/fantasy_etl/transformers/team.py
@@ -17,25 +17,110 @@ class TeamTransformers:
         """
         从团队数据中转换提取团队键
         
-        迁移自: archive/yahoo_api_data.py transform_team_keys_from_data() 第668行
+        迁移自: archive/yahoo_api_data.py transform_team_keys_from_data() 第667行
         """
-        # TODO: 迁移实现
-        # 解析复杂的团队数据结构
-        # 提取所有团队的team_key标识符
-        # 用于后续的团队相关API调用
-        pass
+        team_keys = []
         
-    def transform_team_data_from_api(self, team_data: List) -> Dict:
+        try:
+            fantasy_content = teams_data["fantasy_content"]
+            league_data = fantasy_content["league"]
+            
+            teams_container = None
+            if isinstance(league_data, list) and len(league_data) > 1:
+                for item in league_data:
+                    if isinstance(item, dict) and "teams" in item:
+                        teams_container = item["teams"]
+                        break
+            
+            if teams_container:
+                teams_count = int(teams_container.get("count", 0))
+                for i in range(teams_count):
+                    str_index = str(i)
+                    if str_index in teams_container:
+                        team_container = teams_container[str_index]
+                        if "team" in team_container:
+                            team_data = team_container["team"]
+                            # 修复：team_data[0] 是一个字典列表，不是嵌套列表
+                            if (isinstance(team_data, list) and 
+                                len(team_data) > 0 and 
+                                isinstance(team_data[0], list)):
+                                # 从team_data[0]列表中查找包含team_key的字典
+                                for team_item in team_data[0]:
+                                    if isinstance(team_item, dict) and "team_key" in team_item:
+                                        team_key = team_item["team_key"]
+                                        if team_key:
+                                            team_keys.append(team_key)
+                                        break
+        
+        except Exception as e:
+            print(f"提取团队键时出错: {e}")
+        
+        return team_keys
+        
+    def transform_team_data_from_api(self, team_data: List) -> Optional[Dict]:
         """
         从API团队数据中提取团队信息
         
-        迁移自: archive/yahoo_api_data.py transform_team_data_from_api() 第407行
+        迁移自: archive/yahoo_api_data.py transform_team_data_from_api() 第413行
         """
-        # TODO: 迁移实现
-        # 处理复杂的嵌套数据结构
-        # 提取团队logo、管理员、交易次数等信息  
-        # 规范化团队数据格式
-        pass
+        if not team_data or not isinstance(team_data, list):
+            return None
+        
+        team_info = {}
+        managers = []
+        
+        try:
+            # 第一个元素通常包含团队基本信息
+            if len(team_data) > 0 and isinstance(team_data[0], list):
+                for item in team_data[0]:
+                    if isinstance(item, dict):
+                        # 提取团队基本信息
+                        for key in ['team_key', 'team_id', 'name', 'url', 'team_logo', 
+                                   'waiver_priority', 'number_of_moves', 'number_of_trades',
+                                   'clinched_playoffs', 'draft_grade', 'draft_recap_url']:
+                            if key in item:
+                                team_info[key] = item[key]
+                        
+                        # 处理team_logos
+                        if 'team_logos' in item and isinstance(item['team_logos'], list):
+                            for logo_item in item['team_logos']:
+                                if isinstance(logo_item, dict) and 'team_logo' in logo_item:
+                                    logo_info = logo_item['team_logo']
+                                    if isinstance(logo_info, dict) and 'url' in logo_info:
+                                        team_info['team_logo_url'] = logo_info['url']
+                                        break
+                        
+                        # 处理roster_adds
+                        if 'roster_adds' in item:
+                            roster_adds = item['roster_adds']
+                            if isinstance(roster_adds, dict):
+                                team_info['roster_adds_coverage_type'] = roster_adds.get('coverage_type')
+                                team_info['roster_adds_coverage_value'] = roster_adds.get('coverage_value')
+                                team_info['roster_adds_value'] = roster_adds.get('value')
+                        
+                        # 处理managers
+                        if 'managers' in item and isinstance(item['managers'], list):
+                            for manager_item in item['managers']:
+                                if isinstance(manager_item, dict) and 'manager' in manager_item:
+                                    manager_info = manager_item['manager']
+                                    if isinstance(manager_info, dict):
+                                        managers.append({
+                                            'manager_id': manager_info.get('manager_id'),
+                                            'nickname': manager_info.get('nickname'),
+                                            'guid': manager_info.get('guid'),
+                                            'email': manager_info.get('email'),
+                                            'image_url': manager_info.get('image_url')
+                                        })
+        
+        except Exception as e:
+            print(f"提取团队数据时出错: {e}")
+            return None
+        
+        # 添加管理员信息到团队数据
+        if managers:
+            team_info['managers'] = managers
+        
+        return team_info
     
     # ============================================================================
     # 团队排名和统计转换
@@ -45,36 +130,111 @@ class TeamTransformers:
         """
         从团队数据中提取排名信息
         
-        迁移自: archive/yahoo_api_data.py transform_team_standings_info() 第1101行
+        迁移自: archive/yahoo_api_data.py transform_team_standings_info() 第1100行
         """
-        # TODO: 迁移实现
-        # 递归解析复杂的嵌套数据结构
-        # 提取排名、积分、胜负记录
-        # 处理各种数据格式的异常情况
-        pass
+        if not team_data:
+            return None
+        
+        try:
+            # 检查是否是列表格式
+            if isinstance(team_data, list):
+                # 递归搜索team_standings
+                for item in team_data:
+                    if isinstance(item, dict):
+                        if 'team_standings' in item:
+                            return item['team_standings']
+                        # 递归搜索
+                        result = self.transform_team_standings_info(item)
+                        if result:
+                            return result
+                    elif isinstance(item, list):
+                        # 递归搜索列表
+                        result = self.transform_team_standings_info(item)
+                        if result:
+                            return result
+            
+            # 检查是否是字典格式
+            elif isinstance(team_data, dict):
+                if 'team_standings' in team_data:
+                    return team_data['team_standings']
+                # 递归搜索字典的值
+                for key, value in team_data.items():
+                    if isinstance(value, (dict, list)):
+                        result = self.transform_team_standings_info(value)
+                        if result:
+                            return result
+        
+        except Exception as e:
+            print(f"提取团队排名信息时出错: {e}")
+        
+        return None
         
     def transform_team_stats_from_matchup_data(self, teams_data: Dict, target_team_key: str) -> Optional[Dict]:
         """
         从对战数据中提取目标团队的统计数据
         
-        迁移自: archive/yahoo_api_data.py transform_team_stats_from_matchup_data() 第1673行
+        迁移自: archive/yahoo_api_data.py transform_team_stats_from_matchup_data() 第1672行
         """
-        # TODO: 迁移实现
-        # 在对战的两个团队中找到目标团队
-        # 提取该团队的统计表现
-        pass
+        try:
+            # teams_data 应该包含 '0' 和 '1' 两个团队
+            for team_index in ['0', '1']:
+                if team_index not in teams_data:
+                    continue
+                
+                team_container = teams_data[team_index]
+                if 'team' not in team_container:
+                    continue
+                
+                team_info = team_container['team']
+                
+                # 查找team_key
+                team_key = None
+                team_stats = None
+                
+                if isinstance(team_info, list):
+                    for item in team_info:
+                        if isinstance(item, list):
+                            # 处理嵌套列表格式
+                            for sub_item in item:
+                                if isinstance(sub_item, dict) and 'team_key' in sub_item:
+                                    team_key = sub_item['team_key']
+                        elif isinstance(item, dict):
+                            if 'team_stats' in item:
+                                team_stats = item['team_stats']
+                
+                # 如果找到目标团队，返回其统计数据
+                if team_key == target_team_key and team_stats:
+                    return team_stats
+        
+        except Exception as e:
+            print(f"从对战数据提取团队统计失败: {e}")
+        
+        return None
         
     def transform_team_stats_from_matchup(self, matchup_data: Dict, target_team_key: str) -> Optional[Dict]:
         """
         从对战数据中提取团队统计
         
-        迁移自: archive/yahoo_api_data.py transform_team_stats_from_matchup() 第2515行
+        迁移自: archive/yahoo_api_data.py transform_team_stats_from_matchup() 第2514行
         """
-        # TODO: 迁移实现
-        # 在对战数据中找到目标团队
-        # 提取该团队的统计数据
-        # 返回标准化的统计字典
-        pass
+        try:
+            # 查找teams数据
+            teams = matchup_data.get('teams', [])
+            
+            for team in teams:
+                if isinstance(team, dict):
+                    team_data = team.get('team', {})
+                    team_key = team_data.get('team_key')
+                    
+                    if team_key == target_team_key:
+                        # 找到目标团队，提取统计数据
+                        team_stats = team_data.get('team_stats', {})
+                        return team_stats
+                            
+        except Exception as e:
+            print(f"从对战数据提取团队统计失败: {e}")
+        
+        return None
     
     # ============================================================================
     # 对战数据转换
@@ -84,49 +244,284 @@ class TeamTransformers:
         """
         从原始matchups数据转换为标准化格式 (纯转换，不写入数据库)
         
-        迁移自: archive/yahoo_api_data.py transform_team_matchups() 第1557行
+        迁移自: archive/yahoo_api_data.py transform_team_matchups() 第1556行
         """
-        # TODO: 迁移实现 (第1557-1599行)
-        # 主要逻辑：
-        # 1. 解析fantasy_content.team结构
-        # 2. 查找matchups容器
-        # 3. 遍历所有matchup记录
-        # 4. 转换每个matchup数据格式  
-        # 5. 返回transformed_matchups列表
-        pass
+        if not matchups_data:
+            return None
+        
+        try:
+            fantasy_content = matchups_data.get("fantasy_content", {})
+            team_data = fantasy_content.get("team", [])
+            
+            # 查找matchups容器
+            matchups_container = None
+            for item in team_data:
+                if isinstance(item, dict) and "matchups" in item:
+                    matchups_container = item["matchups"]
+                    break
+            
+            if not matchups_container:
+                return None
+            
+            matchups_count = int(matchups_container.get("count", 0))
+            
+            transformed_matchups = []
+            
+            for i in range(matchups_count):
+                str_index = str(i)
+                if str_index not in matchups_container:
+                    continue
+                
+                matchup_container = matchups_container[str_index]
+                if "matchup" not in matchup_container:
+                    continue
+                
+                matchup_info = matchup_container["matchup"]
+                
+                # 转换matchup数据
+                transformed = {
+                    "team_key": team_key,
+                    "matchup_info": matchup_info
+                }
+                
+                transformed_matchups.append(transformed)
+            
+            return transformed_matchups
+            
+        except Exception as e:
+            print(f"转换matchups数据时出错: {e}")
+            return None
         
     def transform_matchup_info(self, matchup_info, team_key: str) -> Optional[Dict]:
         """
         从对战数据中提取对战信息
         
-        迁移自: archive/yahoo_api_data.py transform_matchup_info() 第1711行
+        迁移自: archive/yahoo_api_data.py transform_matchup_info() 第1710行
         """
-        # TODO: 迁移实现
-        # 提取周次、日期、状态信息
-        # 判断胜负、平局、季后赛状态
-        # 处理各种布尔值格式转换
-        pass
+        if not matchup_info:
+            return None
+        
+        try:
+            # 提取基本信息
+            week = matchup_info.get('week')
+            week_start = matchup_info.get('week_start')
+            week_end = matchup_info.get('week_end')
+            status = matchup_info.get('status')
+            is_playoffs = matchup_info.get('is_playoffs')
+            is_consolation = matchup_info.get('is_consolation')
+            
+            # 处理布尔值
+            if isinstance(is_playoffs, str):
+                is_playoffs = is_playoffs == '1'
+            if isinstance(is_consolation, str):
+                is_consolation = is_consolation == '1'
+            
+            # 提取胜负信息
+            is_tied = matchup_info.get('is_tied', 0)
+            if isinstance(is_tied, str):
+                is_tied = is_tied == '1'
+            
+            winner_team_key = matchup_info.get('winner_team_key')
+            
+            # 判断是否获胜
+            is_winner = None
+            if winner_team_key:
+                is_winner = winner_team_key == team_key
+            elif is_tied:
+                is_winner = None  # 平局
+            
+            # 提取teams数据中的详细信息
+            teams_data = matchup_info.get('teams', {})
+            team_points = None
+            opponent_team_key = None
+            opponent_points = None
+            
+            # 处理teams数据
+            if teams_data:
+                for team_idx in ['0', '1']:
+                    if team_idx in teams_data:
+                        team_container = teams_data[team_idx]
+                        if 'team' in team_container:
+                            team_info = team_container['team']
+                            current_team_key = None
+                            current_points = None
+                            
+                            # 提取team_key和points
+                            if isinstance(team_info, list):
+                                for item in team_info:
+                                    if isinstance(item, list):
+                                        for sub_item in item:
+                                            if isinstance(sub_item, dict):
+                                                if 'team_key' in sub_item:
+                                                    current_team_key = sub_item['team_key']
+                                                if 'team_points' in sub_item:
+                                                    team_points_data = sub_item['team_points']
+                                                    if isinstance(team_points_data, dict):
+                                                        current_points = team_points_data.get('total')
+                            
+                            # 判断是当前团队还是对手
+                            if current_team_key == team_key:
+                                team_points = current_points
+                            else:
+                                opponent_team_key = current_team_key
+                                opponent_points = current_points
+            
+            # 构建转换后的数据
+            transformed_info = {
+                'week': self._safe_int(week),
+                'week_start': week_start,
+                'week_end': week_end,
+                'status': status,
+                'is_playoffs': is_playoffs,
+                'is_consolation': is_consolation,
+                'is_tied': is_tied,
+                'is_winner': is_winner,
+                'winner_team_key': winner_team_key,
+                'team_points': self._safe_float(team_points),
+                'opponent_team_key': opponent_team_key,
+                'opponent_points': self._safe_float(opponent_points)
+            }
+            
+            return transformed_info
+            
+        except Exception as e:
+            print(f"提取对战信息时出错: {e}")
+            return None
         
     def transform_team_matchup_details(self, teams_data, target_team_key: str) -> Optional[Dict]:
         """
         从teams数据中提取当前团队的对战详情
         
-        迁移自: archive/yahoo_api_data.py transform_team_matchup_details() 第1814行
+        迁移自: archive/yahoo_api_data.py transform_team_matchup_details() 第1813行
         """
-        # TODO: 迁移实现
-        # 识别对战中的两个团队
-        # 提取对手信息和积分对比
-        # 基于积分判断胜负关系
-        pass
+        if not teams_data:
+            return None
+        
+        try:
+            team_info = None
+            opponent_info = None
+            
+            # 遍历teams数据（通常包含 '0' 和 '1' 两个团队）
+            for team_idx in ['0', '1']:
+                if team_idx not in teams_data:
+                    continue
+                
+                team_container = teams_data[team_idx]
+                if 'team' not in team_container:
+                    continue
+                
+                team_data = team_container['team']
+                
+                # 提取团队信息
+                current_team_key = None
+                current_team_points = None
+                current_team_name = None
+                
+                if isinstance(team_data, list):
+                    for item in team_data:
+                        if isinstance(item, list):
+                            for sub_item in item:
+                                if isinstance(sub_item, dict):
+                                    if 'team_key' in sub_item:
+                                        current_team_key = sub_item['team_key']
+                                    if 'name' in sub_item:
+                                        current_team_name = sub_item['name']
+                                    if 'team_points' in sub_item:
+                                        points_data = sub_item['team_points']
+                                        if isinstance(points_data, dict):
+                                            current_team_points = points_data.get('total')
+                
+                # 判断是目标团队还是对手
+                if current_team_key == target_team_key:
+                    team_info = {
+                        'team_key': current_team_key,
+                        'team_name': current_team_name,
+                        'team_points': self._safe_float(current_team_points)
+                    }
+                else:
+                    opponent_info = {
+                        'opponent_team_key': current_team_key,
+                        'opponent_team_name': current_team_name,
+                        'opponent_points': self._safe_float(current_team_points)
+                    }
+            
+            # 如果找到了团队信息，合并数据
+            if team_info:
+                result = team_info.copy()
+                if opponent_info:
+                    result.update(opponent_info)
+                    
+                    # 基于积分判断胜负
+                    if result['team_points'] is not None and result['opponent_points'] is not None:
+                        if result['team_points'] > result['opponent_points']:
+                            result['is_winner'] = True
+                        elif result['team_points'] < result['opponent_points']:
+                            result['is_winner'] = False
+                        else:
+                            result['is_winner'] = None  # 平局
+                
+                return result
+                
+        except Exception as e:
+            print(f"提取对战详情时出错: {e}")
+        
+        return None
         
     def transform_team_weekly_stats(self, matchup_info: Dict, team_key: str) -> Optional[Dict]:
         """
         从matchup数据中转换团队周统计数据 (纯转换，不写入数据库)
         
-        迁移自: archive/yahoo_api_data.py transform_team_weekly_stats() 第1630行
+        迁移自: archive/yahoo_api_data.py transform_team_weekly_stats() 第1629行
         """
-        # TODO: 迁移实现
-        # 从matchup中的teams数据提取统计数据
-        # 调用 transform_team_stats_from_matchup_data
-        # 返回转换后的数据，不直接写入数据库
-        pass
+        if not matchup_info:
+            return None
+        
+        try:
+            # 从matchup中的teams数据提取统计数据
+            teams_data = matchup_info.get('teams', {})
+            
+            if teams_data:
+                # 调用现有方法提取统计数据
+                team_stats = self.transform_team_stats_from_matchup_data(teams_data, team_key)
+                
+                if team_stats:
+                    # 提取其他信息
+                    week = matchup_info.get('week')
+                    is_playoffs = matchup_info.get('is_playoffs', False)
+                    
+                    # 构建转换后的数据
+                    transformed_stats = {
+                        'team_key': team_key,
+                        'week': self._safe_int(week),
+                        'is_playoffs': is_playoffs,
+                        'stats': team_stats
+                    }
+                    
+                    return transformed_stats
+                    
+        except Exception as e:
+            print(f"转换团队周统计时出错: {e}")
+        
+        return None
+    
+    # ============================================================================
+    # 辅助函数
+    # ============================================================================
+    
+    def _safe_int(self, value) -> Optional[int]:
+        """安全转换为整数"""
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return None
+    
+    def _safe_float(self, value) -> Optional[float]:
+        """安全转换为浮点数"""
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return None


### PR DESCRIPTION
Migrate all remaining data transformation functions to the `fantasy_etl/transformers` module to complete the modularization of the ETL framework, ensuring pure and testable functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-e648b288-e92c-4c7e-b9c0-5d45e8ebc54b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e648b288-e92c-4c7e-b9c0-5d45e8ebc54b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>